### PR TITLE
remove unused Mutex

### DIFF
--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -387,8 +387,6 @@ impl SimulatedNode {
 
                                 let outgoing_msg: Option<Msg<String>> = {
                                     thread_local_node
-                                        .lock()
-                                        .expect("thread_local_node lock failed when nominating value")
                                         .nominate(
                                             current_slot as SlotIndex,
                                             BTreeSet::from_iter(values_to_nominate)
@@ -407,8 +405,6 @@ impl SimulatedNode {
                         for msg in incoming_msgs.iter() {
                             let outgoing_msg: Option<Msg<String>> = {
                                 thread_local_node
-                                    .lock()
-                                    .expect("thread_local_node lock failed when handling msg")
                                     .handle(msg)
                                     .expect("node.handle_msg() failed")
                             };
@@ -422,8 +418,6 @@ impl SimulatedNode {
                         // Process timeouts (for all slots)
                         let timeout_msgs: Vec<Msg<String>> = {
                             thread_local_node
-                                .lock()
-                                .expect("thread_local_node lock failed when processing timeouts")
                                 .process_timeouts()
                                 .into_iter()
                                 .collect()
@@ -436,8 +430,6 @@ impl SimulatedNode {
                         // Check if the current slot is done
                         let new_block:Vec<String> = {
                             thread_local_node
-                              .lock()
-                              .expect("thread_local_node lock failed when collecting externalized values")
                               .get_externalized_values(current_slot as SlotIndex)
                         };
 

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -387,6 +387,8 @@ impl SimulatedNode {
 
                                 let outgoing_msg: Option<Msg<String>> = {
                                     thread_local_node
+                                        .lock()
+                                        .expect("thread_local_node lock failed when nominating value")
                                         .nominate(
                                             current_slot as SlotIndex,
                                             BTreeSet::from_iter(values_to_nominate)
@@ -405,6 +407,8 @@ impl SimulatedNode {
                         for msg in incoming_msgs.iter() {
                             let outgoing_msg: Option<Msg<String>> = {
                                 thread_local_node
+                                    .lock()
+                                    .expect("thread_local_node lock failed when handling msg")
                                     .handle(msg)
                                     .expect("node.handle_msg() failed")
                             };
@@ -418,6 +422,8 @@ impl SimulatedNode {
                         // Process timeouts (for all slots)
                         let timeout_msgs: Vec<Msg<String>> = {
                             thread_local_node
+                                .lock()
+                                .expect("thread_local_node lock failed when processing timeouts")
                                 .process_timeouts()
                                 .into_iter()
                                 .collect()
@@ -430,6 +436,8 @@ impl SimulatedNode {
                         // Check if the current slot is done
                         let new_block:Vec<String> = {
                             thread_local_node
+                              .lock()
+                              .expect("thread_local_node lock failed when collecting externalized values")
                               .get_externalized_values(current_slot as SlotIndex)
                         };
 

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -190,9 +190,7 @@ impl SimulatedNetwork {
         for node_num in 0..num_nodes {
             nodes_map
                 .get_mut(&test_utils::test_node_id(node_num as u32))
-                .expect("failed to get node from nodes_map")
-                .lock()
-                .expect("lock failed on node sending stop")
+                .expect("could not find node_id in nodes_map")
                 .send_stop();
         }
         drop(nodes_map);
@@ -212,18 +210,16 @@ impl SimulatedNetwork {
     fn push_value(&self, node_id: &NodeID, value: &str) {
         self.nodes_map
             .lock()
-            .expect("lock failed on nodes_map getting node")
+            .expect("lock failed on nodes_map pushing value")
             .get(node_id)
             .expect("could not find node_id in nodes_map")
-            .lock()
-            .expect("lock failed on node sending value")
             .send_value(value);
     }
 
     fn get_ledger(&self, node_id: &NodeID) -> Vec<Vec<String>> {
         self.nodes_shared_data
             .get(node_id)
-            .expect("could not find node_id in nodes_map")
+            .expect("could not find node_id in nodes_shared_data")
             .lock()
             .expect("lock failed on shared_data getting ledger")
             .ledger
@@ -233,7 +229,7 @@ impl SimulatedNetwork {
     fn get_ledger_size(&self, node_id: &NodeID) -> usize {
         self.nodes_shared_data
             .get(node_id)
-            .expect("could not find node_id in nodes_map")
+            .expect("could not find node_id in nodes_shared_data")
             .lock()
             .expect("lock failed on shared_data getting ledger size")
             .ledger_size()

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -304,7 +304,7 @@ impl SimulatedNode {
             shared_data: Arc::new(Mutex::new(SimulatedNodeSharedData { ledger: Vec::new() })),
         };
 
-        let thread_local_node = Node::new(
+        let mut thread_local_node = Node::new(
             node_id.clone(),
             quorum_set,
             test_options.validity_fn.clone(),

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -191,6 +191,8 @@ impl SimulatedNetwork {
             nodes_map
                 .get_mut(&test_utils::test_node_id(node_num as u32))
                 .expect("failed to get node from nodes_map")
+                .lock()
+                .expect("lock failed on node sending stop")
                 .send_stop();
         }
         drop(nodes_map);
@@ -213,6 +215,8 @@ impl SimulatedNetwork {
             .expect("lock failed on nodes_map getting node")
             .get(node_id)
             .expect("could not find node_id in nodes_map")
+            .lock()
+            .expect("lock failed on node sending value")
             .send_value(value);
     }
 
@@ -245,7 +249,7 @@ impl SimulatedNetwork {
             .lock()
             .expect("lock failed on nodes_map in broadcast");
 
-        log::trace!(logger, "(broadcast) {}", msg.to_display(),);
+        log::trace!(logger, "(broadcast) {}", msg.to_display());
 
         let amsg = Arc::new(msg);
 


### PR DESCRIPTION
The SCP node is only used by the SimulatedNode thread.